### PR TITLE
Fix missing exec permission on the fan installed script

### DIFF
--- a/install-fan-service.sh
+++ b/install-fan-service.sh
@@ -3,6 +3,7 @@
 echo "Start installing fan service..."
 
 sudo cp -f ./x-c1-fan.sh                /usr/local/bin/
+sudo chmod +x /usr/local/bin/x-c1-fan.sh
 sudo cp -f ./x-c1-fan.service           /lib/systemd/system
 sudo systemctl daemon-reload
 sudo systemctl enable x-c1-fan


### PR DESCRIPTION
This fixes an issue where the fan script doesn't have execution permission and the service fails.

journalctl:
```
(1-fan.sh)[1011]: x-c1-fan.service: Failed at step EXEC spawning /usr/local/bin/x-c1-fan.sh: Permission denied
(1-fan.sh)[1011]: x-c1-fan.service: Failed to locate executable /usr/local/bin/x-c1-fan.sh: Permission denied
```